### PR TITLE
ブランチ元変更処理

### DIFF
--- a/data/tusb_remake/functions/gimmic/clock/1.mcfunction
+++ b/data/tusb_remake/functions/gimmic/clock/1.mcfunction
@@ -5,21 +5,21 @@
 
 ### 達成率が11~40
 ### 時計の針襲撃スポナーを修正
-#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {SpawnData:{entity:{id:"minecraft:villager",Health:0f,DeathTime:19s,Passengers:[{id:"minecraft:enderman",CustomName:'"秒針"',DeathLootTable:"usb:entities/clock",Health:50f,Attributes:[{Name:"minecraft:generic.max_health",Base:50d},{Name:"minecraft:generic.movement_speed",Base:0.45d},{Name:"minecraft:generic.attack_damage",Base:6d}],carriedBlockState:{Name:"minecraft:water"}}]}}}
-#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {RequiredPlayerRange:32s,Delay:100s}
-#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data remove block ~ ~ ~ SpawnPotentials
+execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {SpawnData:{entity:{id:"minecraft:villager",Health:0f,DeathTime:19s,Passengers:[{id:"minecraft:enderman",CustomName:'"秒針"',DeathLootTable:"usb:entities/clock",Health:50f,Attributes:[{Name:"minecraft:generic.max_health",Base:50d},{Name:"minecraft:generic.movement_speed",Base:0.45d},{Name:"minecraft:generic.attack_damage",Base:6d}],carriedBlockState:{Name:"minecraft:water"}}]}}}
+execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {RequiredPlayerRange:32s,Delay:100s}
+execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data remove block ~ ~ ~ SpawnPotentials
 
 ### 時計島変身
-#execute in minecraft:overworld positioned 4001 47 4001 run function tusb_remake:gimmic/clock/clone
+execute in minecraft:overworld positioned 4001 47 4001 run function tusb_remake:gimmic/clock/clone
 
 ### 時計島の段階を記録
-#data modify storage tusb_remake: clock_stage set value 1
+data modify storage tusb_remake: clock_stage set value 1
 
 # 追加部分
 
 #検証用
-data modify storage tusb_remake: clock_ring_time set value 180
-execute in minecraft:overworld run schedule function tusb_remake:gimmic/clock/ring 1t
+#data modify storage tusb_remake: clock_ring_time set value 180
+#execute in minecraft:overworld run schedule function tusb_remake:gimmic/clock/ring 1t
 
 # 演出
 worldborder warning distance 20000

--- a/data/tusb_remake/functions/gimmic/clock/1.mcfunction
+++ b/data/tusb_remake/functions/gimmic/clock/1.mcfunction
@@ -5,18 +5,26 @@
 
 ### 達成率が11~40
 ### 時計の針襲撃スポナーを修正
-execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {SpawnData:{entity:{id:"minecraft:villager",Health:0f,DeathTime:19s,Passengers:[{id:"minecraft:enderman",CustomName:'"秒針"',DeathLootTable:"usb:entities/clock",Health:50f,Attributes:[{Name:"minecraft:generic.max_health",Base:50d},{Name:"minecraft:generic.movement_speed",Base:0.45d},{Name:"minecraft:generic.attack_damage",Base:6d}],carriedBlockState:{Name:"minecraft:water"}}]}}}
-execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {RequiredPlayerRange:32s,Delay:100s}
-execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data remove block ~ ~ ~ SpawnPotentials
+#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {SpawnData:{entity:{id:"minecraft:villager",Health:0f,DeathTime:19s,Passengers:[{id:"minecraft:enderman",CustomName:'"秒針"',DeathLootTable:"usb:entities/clock",Health:50f,Attributes:[{Name:"minecraft:generic.max_health",Base:50d},{Name:"minecraft:generic.movement_speed",Base:0.45d},{Name:"minecraft:generic.attack_damage",Base:6d}],carriedBlockState:{Name:"minecraft:water"}}]}}}
+#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {RequiredPlayerRange:32s,Delay:100s}
+#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data remove block ~ ~ ~ SpawnPotentials
 
 ### 時計島変身
-execute in minecraft:overworld positioned 4001 47 4001 run function tusb_remake:gimmic/clock/clone
+#execute in minecraft:overworld positioned 4001 47 4001 run function tusb_remake:gimmic/clock/clone
 
 ### 時計島の段階を記録
-data modify storage tusb_remake: clock_stage set value 1
+#data modify storage tusb_remake: clock_stage set value 1
 
 # 追加部分
 
+#検証用
+data modify storage tusb_remake: clock_ring_time set value 180
+execute in minecraft:overworld run schedule function tusb_remake:gimmic/clock/ring 1t
+
+# 演出
+worldborder warning distance 20000
+weather thunder 7d
+execute in minecraft:overworld run schedule function tusb_remake:gimmic/clock/half_tick 10t
 # msg(一旦これ、いいのあったら変えたいです)
 tellraw @a [{"text":"時の流れがおかしくなった気がする。","bold": false,"color": "red"}]
 tellraw @a [{"text":"すぐに時の乱れを止めないと。","bold": false,"color": "red"}]

--- a/data/tusb_remake/functions/gimmic/clock/half_tick.mcfunction
+++ b/data/tusb_remake/functions/gimmic/clock/half_tick.mcfunction
@@ -1,0 +1,11 @@
+#> tusb_remake:gimmic/clock/half_tick
+#
+# 時計島がおかしくなってる間の演出
+#
+#
+
+execute as @a at @s run playsound block.comparator.click master @p ~ ~100 ~ 0.5 0.5 0.3
+
+
+# 止まるまで繰り返し
+execute unless score Cloak Changed_Form matches 0 in minecraft:overworld run schedule function tusb_remake:gimmic/clock/half_tick 10t

--- a/data/tusb_remake/functions/gimmic/clock/ring.mcfunction
+++ b/data/tusb_remake/functions/gimmic/clock/ring.mcfunction
@@ -1,0 +1,14 @@
+#> tusb_remake:gimmic/clock/ring
+# 時計島うるさい
+### Copyright © 2022 フレイシェル
+### This software is released under the MIT License, see LICENSE.
+
+# 時計鳴らす
+execute as @a at @s run playsound minecraft:block.anvil.land master @p ~ ~100 ~ 0.5 1.414 0.3
+# 朝にする
+time set 23400
+
+# カウントダウン
+execute store result storage tusb_remake: clock_ring_time int 0.9999999999 run data get storage tusb_remake: clock_ring_time
+# 止まるまで繰り返し
+execute unless data storage tusb_remake: {clock_ring_time:0} in minecraft:overworld run schedule function tusb_remake:gimmic/clock/ring 1t

--- a/data/tusb_remake/functions/gimmic/clock/stop.mcfunction
+++ b/data/tusb_remake/functions/gimmic/clock/stop.mcfunction
@@ -3,8 +3,8 @@
 ### Copyright © 2022 赤石愛
 ### This software is released under the MIT License, see LICENSE.
 
-execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {RequiredPlayerRange:0s,Delay:32767s}
-execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data remove block ~ ~ ~ SpawnPotentials
+#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {RequiredPlayerRange:0s,Delay:32767s}
+#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data remove block ~ ~ ~ SpawnPotentials
 
 execute as @a at @s run playsound minecraft:block.anvil.land master @s ~ ~100 ~ 0.6 1.414 0.6
 tellraw @a {"text":"時計が止まった。","color":"gold"}
@@ -15,3 +15,7 @@ tellraw @a {"text":"時計が止まった。","color":"gold"}
 scoreboard players set Cloak Changed_Form 0
 # 戻ってそうな音
 execute as @a at @s run playsound minecraft:item.trident.thunder master @s ~ ~ ~ 1 1
+# 演出戻す
+weather clear 7d
+worldborder warning distance 0
+execute in minecraft:overworld run schedule clear tusb_remake:gimmic/clock/half_tick

--- a/data/tusb_remake/functions/gimmic/clock/stop.mcfunction
+++ b/data/tusb_remake/functions/gimmic/clock/stop.mcfunction
@@ -3,8 +3,8 @@
 ### Copyright © 2022 赤石愛
 ### This software is released under the MIT License, see LICENSE.
 
-#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {RequiredPlayerRange:0s,Delay:32767s}
-#execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data remove block ~ ~ ~ SpawnPotentials
+execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data merge block ~ ~ ~ {RequiredPlayerRange:0s,Delay:32767s}
+execute in minecraft:overworld positioned -58 23 22 if block ~ ~ ~ minecraft:spawner run data remove block ~ ~ ~ SpawnPotentials
 
 execute as @a at @s run playsound minecraft:block.anvil.land master @s ~ ~100 ~ 0.6 1.414 0.6
 tellraw @a {"text":"時計が止まった。","color":"gold"}


### PR DESCRIPTION
freyブランチがmainブランチと紐づいているので現在の作業内容をdevelopに送る処理を行う。
適切に移行ができたら一度ブランチを削除し、developブランチから生やすようにする
(こうするといちいちpull request送るときに送信先をdevelopに変える必要がないはず)
後mainと紐づいてると何かしらめんどいことがありそうなので、、、()